### PR TITLE
chore: Use setup-node action to cache dependencies

### DIFF
--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -13,18 +13,7 @@ jobs:
         uses: actions/setup-node@v3
         with:
           node-version: '16'
-
-      - name: Get yarn cache
-        id: yarn-cache
-        run: echo "::set-output name=dir::$(yarn cache dir)"
-
-      - name: Cache dependencies
-        uses: actions/cache@v2
-        with:
-          path: ${{ steps.yarn-cache.outputs.dir }}
-          key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
-          restore-keys: |
-            ${{ runner.os }}-yarn-
+          cache: yarn
 
       - name: Build packages
         run: |


### PR DESCRIPTION
Signed-off-by: jongwooo <han980817@gmail.com>

## Description

I changed the workflow to cache dependencies using [actions/setup-node](https://github.com/actions/setup-node#caching-global-packages-data). `actions/setup-node@v2` or newer has caching **built-in** so you no longer need to setup `actions/cache`.

### AS-IS

```yml
- name: Setup Node
  uses: actions/setup-node@v3
  with:
    node-version: '16'

- name: Get yarn cache
  id: yarn-cache
  run: echo "::set-output name=dir::$(yarn cache dir)"

- name: Cache dependencies
  uses: actions/cache@v2
  with:
    path: ${{ steps.yarn-cache.outputs.dir }}
    key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
    restore-keys: |
      ${{ runner.os }}-yarn-
```

### TO-BE

```yml
- name: Setup Node
  uses: actions/setup-node@v3
  with:
    node-version: '16'
    cache: yarn
```

> It’s literally a one line change to pass the `cache: yarn` input parameter.

## References

- [https://docs.github.com/en/actions/using-workflows/caching-dependencies-to-speed-up-workflows](https://docs.github.com/en/actions/using-workflows/caching-dependencies-to-speed-up-workflows)
- [https://thearchivelog.dev/article/caching-dependencies-to-speed-up-workflows/](https://thearchivelog.dev/article/caching-dependencies-to-speed-up-workflows/)